### PR TITLE
Ripple fixed on mobile devices

### DIFF
--- a/scripts/ripples.js
+++ b/scripts/ripples.js
@@ -173,7 +173,7 @@
        */
       event = event.originalEvent;
 
-      if(event.touches.length !== 1) {
+      if(event.touches.length == 1) {
         return event.touches[0].pageX - wrapperOffset.left;
       }
 
@@ -200,7 +200,7 @@
        */
       event = event.originalEvent;
 
-      if(event.touches.length !== 1) {
+      if(event.touches.length == 1) {
         return event.touches[0].pageY - wrapperOffset.top;
       }
 


### PR DESCRIPTION
Ripple fixed on mobile devices: `Ripples.prototype.getRelX` and `Ripples.prototype.getRelY` didn't work on mobile devices when touched with one finger only. Now it's fixed.
